### PR TITLE
Brew 1.1.10 didn't like the "name" attribute

### DIFF
--- a/Formula/cp-remote.rb
+++ b/Formula/cp-remote.rb
@@ -1,9 +1,8 @@
 class CpRemote < Formula
-  name "cp-remote"
   desc "Tool to create and sync code to a Continuous Pipe remote environment"
-  homepage "hhttps://docs.continuouspipe.io/guides/remote-development/"
-  url "https://continuouspipe.github.io/remote-environment-client/#{version}/darwin-amd64.gz"
+  homepage "https://docs.continuouspipe.io/guides/remote-development/"
   version '0.0.1'
+  url "https://continuouspipe.github.io/remote-environment-client/#{version}/darwin-amd64.gz"
   sha256 "b6e3d958562122e6438d528ccdd944418f93d64a040561e8cc04f24f4bd736a9"
 
   def install


### PR DESCRIPTION
Despite the "name" attribute being in the base file, brew 1.1.10 didn't like the name attribute at all:
```
$ brew install --debug cp-remote
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/inviqa/homebrew-tools/Formula/cp-remote.rb
Error: wrong number of arguments (1 for 0)
Please report this bug:
  http://docs.brew.sh/Troubleshooting.html
/usr/local/Homebrew/Library/Taps/inviqa/homebrew-tools/Formula/cp-remote.rb:2:in `name'
/usr/local/Homebrew/Library/Taps/inviqa/homebrew-tools/Formula/cp-remote.rb:2:in `<class:CpRemote>'
/usr/local/Homebrew/Library/Taps/inviqa/homebrew-tools/Formula/cp-remote.rb:1:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `module_eval'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:46:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:101:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:92:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:88:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:259:in `factory'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:432:in `find_with_priority'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:45:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:41:in `map'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:41:in `formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:104:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```

I also had to swap around the version and url so that ruby would embed the variable correctly.