### PR TITLE
Fix compatibility with latest cask DSL + bundled ruby version

### DIFF
--- a/Casks/hem.rb
+++ b/Casks/hem.rb
@@ -5,11 +5,10 @@ cask 'hem' do
   url "https://dx6pc3giz7k1r.cloudfront.net/hem/versions/#{version}/hem-#{version}.dmg"
   name 'Hem'
   homepage 'https://github.com/inviqa/hem'
-  license :mit
 
   pkg "hem-#{version}.pkg"
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
   To enable access to the ruby installation and installed gems,
   add to your profile:
     if which hem > /dev/null; then eval "$(hem shell-init bash)"; fi


### PR DESCRIPTION
`/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/` is bundled with Homebrew now, so compatibility with 2.3.x is needed.

Also fix the fact that license is deprecated.